### PR TITLE
chore: use f-string builtin format specifier

### DIFF
--- a/README.org
+++ b/README.org
@@ -209,13 +209,13 @@ find a solution I'll update this document.
   let main () =
       let resultMoney = calcMoney (X_0) (Y) (H) (N)
 
-      printfn """
-      Initial money: %.2f
-      Addition per month: %.2f
-      Increase rate per month: %.2f
-      Investment time: %i months
-      Final value: %.2f moneys
-      """ (X_0) (Y) (H) (N) (resultMoney)
+      printfn $"""
+      Initial money: %.2f{X_0}
+      Addition per month: %.2f{Y}
+      Increase rate per month: %.2f{H}
+      Investment time: %i{N} months
+      Final value: %.2f{resultMoney} moneys
+      """
 
   main ()
 #+END_SRC

--- a/README.org
+++ b/README.org
@@ -169,11 +169,11 @@ the right header configuration for the block.
     resultMoney = calcMoney(X_0, Y, H, N)
 
     return f"""
-    Initial money: {format(X_0, '.2f')}
-    Addition per month: {format(Y, '.2f')}
-    Increase rate per month: {format(H, '.2f')}
+    Initial money: {X_0:.2f}
+    Addition per month: {Y:.2f}
+    Increase rate per month: {H:.2f}
     Investment time: {N} months
-    Final value: {format(resultMoney, '.2f')} moneys
+    Final value: {resultMoney:.2f} moneys
     """
 
   return main()

--- a/finance.fsx
+++ b/finance.fsx
@@ -13,12 +13,12 @@ let rec calcMoney (x0: float) (y: float) (h: float) (nMonth: int): float =
 let main () =
     let resultMoney = calcMoney (X_0) (Y) (H) (N)
 
-    printfn """
-    Initial money: %.2f
-    Addition per month: %.2f
-    Increase rate per month: %.2f
-    Investment time: %i months
-    Final value: %.2f moneys
-    """ (X_0) (Y) (H) (N) (resultMoney)
+    printfn $"""
+    Initial money: %.2f{X_0}
+    Addition per month: %.2f{Y}
+    Increase rate per month: %.2f{H}
+    Investment time: %i{N} months
+    Final value: %.2f{resultMoney} moneys
+    """
 
 main ()

--- a/finance.py
+++ b/finance.py
@@ -26,11 +26,11 @@ def main ():
   resultMoney = calcMoney(X_0, Y, H, N)
 
   return f"""
-  Initial money: {format(X_0, '.2f')}
-  Addition per month: {format(Y, '.2f')}
-  Increase rate per month: {format(H, '.2f')}
+  Initial money: {X_0:.2f}
+  Addition per month: {Y:.2f}
+  Increase rate per month: {H:.2f}
   Investment time: {N} months
-  Final value: {format(resultMoney, '.2f')} moneys
+  Final value: {resultMoney:.2f} moneys
   """
 
 return main()


### PR DESCRIPTION
This makes the code even more readable (IMHO).

Nice repo BTW. I will check if you can now get rid of your F# workaround: https://github.com/juergenhoetzel/ob-fsharp/issues/1